### PR TITLE
static headers and recursion fix

### DIFF
--- a/bin/deploy/static_version_cache
+++ b/bin/deploy/static_version_cache
@@ -99,6 +99,7 @@ sub get_git_tree {
              };
 
     for my $submodule (@submodules) {
+        next if $submodule eq $root; # prevent recursion
         my $sub = get_git_tree($submodule, '.');
         $sub = { map { ("/$submodule$_" => $sub->{$_}) } keys %$sub };
         $files = { %$files, %$sub };

--- a/combust.conf.sample
+++ b/combust.conf.sample
@@ -98,6 +98,11 @@ default=1
 
 
 # Configure sites
+[headers-global]
+X-Frame-Options = deny
+
+[headers-www]
+X-Frame-Options = sameorigin
 
 [www]
 servername = new.c.askask.com

--- a/lib/Combust/Config.pm
+++ b/lib/Combust/Config.pm
@@ -349,5 +349,14 @@ sub apache_loglevel {
   $cfg->param('apache.loglevel') || "info";
 }
 
+sub static_headers {
+  my $self = shift;
+  my $sitename = shift or carp "sitename parameter required" and return;
+  my %headers = (
+    %{$cfg->get_block("headers-global")},
+    %{$cfg->get_block("headers-${sitename}")});
+  return %headers;
+}
+
 1;
 

--- a/lib/Combust/Control.pm
+++ b/lib/Combust/Control.pm
@@ -294,6 +294,11 @@ sub send_output {
 
   $self->cookies->bake_cookies;
 
+  my %headers = $config->static_headers($self->site);
+  while (my ($k, $v) = each %headers)  {
+    $self->request->header_out($k, $v);
+  }
+
   $self->request->header_out('P3P', q[CP="There's no P3P policy. Learn why here: http://www.w3.org/P3P/"]);
 
   if ($self->no_cache) {


### PR DESCRIPTION

static headers is for security headers and other things that won't change and we want to apply globally

recursion fix has been sitting in my working copy for who knows how long.